### PR TITLE
fix: improve Google Photos EXIF compatibility

### DIFF
--- a/src/exif/processors.rs
+++ b/src/exif/processors.rs
@@ -754,117 +754,140 @@ impl JpegProcessor {
       value_or_offset: u32,
     }
 
-    let mut entries = Vec::new();
-    let mut external_data = Vec::new();
+    // -------- IFD0 (primary) --------
+    let mut ifd0_entries: Vec<ExifEntry> = Vec::new();
+    let mut ifd0_external: Vec<u8> = Vec::new();
 
-    // Helper closure to add ASCII string entry
-    let mut add_string_entry = |tag: u16, text: &str| {
-      let text_bytes = text.as_bytes();
-      let count = (text_bytes.len() + 1) as u32; // +1 for null terminator
-
+    let mut add_ifd0_ascii = |tag: u16, text: &str| {
+      let bytes = text.as_bytes();
+      let count = (bytes.len() + 1) as u32;
       if count <= 4 {
-        // String fits in value field
-        let mut value_bytes = [0u8; 4];
-        value_bytes[..text_bytes.len()].copy_from_slice(text_bytes);
-        // null terminator is already there from initialization
-        entries.push(ExifEntry {
-          tag,
-          field_type: 2, // ASCII
-          count,
-          value_or_offset: u32::from_le_bytes(value_bytes),
-        });
+        let mut v = [0u8; 4];
+        v[..bytes.len()].copy_from_slice(bytes);
+        ifd0_entries.push(ExifEntry { tag, field_type: 2, count, value_or_offset: u32::from_le_bytes(v) });
       } else {
-        // String needs external storage
-        let offset = external_data.len() as u32;
-        external_data.extend_from_slice(text_bytes);
-        external_data.push(0); // null terminator
-
-        entries.push(ExifEntry {
-          tag,
-          field_type: 2, // ASCII
-          count,
-          value_or_offset: offset,
-        });
+        let off = ifd0_external.len() as u32;
+        ifd0_external.extend_from_slice(bytes);
+        ifd0_external.push(0);
+        ifd0_entries.push(ExifEntry { tag, field_type: 2, count, value_or_offset: off });
       }
     };
 
-    // Add basic EXIF entries
-    add_string_entry(0x010F, &selection.camera.maker); // Make
-    add_string_entry(0x0110, &selection.camera.model); // Model
-    add_string_entry(0x013B, &selection.photographer.name); // Artist
+    add_ifd0_ascii(0x010F, &selection.camera.maker); // Make
+    add_ifd0_ascii(0x0110, &selection.camera.model); // Model
+    add_ifd0_ascii(0x013B, &selection.photographer.name); // Artist
 
-    // Add lens entries if present
-    let lens_model_string;
-    if let Some(lens) = &selection.lens {
-      add_string_entry(0xA433, &lens.maker); // LensMake
-      lens_model_string = lens.complete_lens_model();
-      add_string_entry(0xA434, &lens_model_string); // LensModel
+    // Placeholder ExifIFDPointer (0x8769), LONG
+    ifd0_entries.push(ExifEntry { tag: 0x8769, field_type: 4, count: 1, value_or_offset: 0 });
+
+    // Sort entries
+    ifd0_entries.sort_by_key(|e| e.tag);
+
+    // Compute IFD0 external data start (from TIFF start)
+    let ifd0_external_offset = 8 + 2 + (ifd0_entries.len() * 12) + 4;
+
+    // We'll serialize IFD0 to a buffer so we can patch ExifIFDPointer later
+    let mut ifd0_buf = Vec::new();
+    ifd0_buf.extend_from_slice(&(ifd0_entries.len() as u16).to_le_bytes());
+    for e in &ifd0_entries {
+      ifd0_buf.extend_from_slice(&e.tag.to_le_bytes());
+      ifd0_buf.extend_from_slice(&e.field_type.to_le_bytes());
+      ifd0_buf.extend_from_slice(&e.count.to_le_bytes());
+      if e.field_type == 2 && e.count > 4 {
+        let adj = (ifd0_external_offset as u32) + e.value_or_offset;
+        ifd0_buf.extend_from_slice(&adj.to_le_bytes());
+      } else {
+        ifd0_buf.extend_from_slice(&e.value_or_offset.to_le_bytes());
+      }
+    }
+    // next IFD = 0
+    ifd0_buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+    ifd0_buf.extend_from_slice(&ifd0_external);
+
+    // -------- Exif SubIFD --------
+    let mut exif_entries: Vec<ExifEntry> = Vec::new();
+    let mut exif_external: Vec<u8> = Vec::new();
+
+    #[allow(clippy::items_after_statements)]
+    fn add_exif_ascii(entries: &mut Vec<ExifEntry>, external: &mut Vec<u8>, tag: u16, text: &str) {
+      let bytes = text.as_bytes();
+      let count = (bytes.len() + 1) as u32;
+      if count <= 4 {
+        let mut v = [0u8; 4];
+        v[..bytes.len()].copy_from_slice(bytes);
+        entries.push(ExifEntry { tag, field_type: 2, count, value_or_offset: u32::from_le_bytes(v) });
+      } else {
+        let off = external.len() as u32;
+        external.extend_from_slice(bytes);
+        external.push(0);
+        entries.push(ExifEntry { tag, field_type: 2, count, value_or_offset: off });
+      }
     }
 
-    // Add ISO entry (SHORT type)
+    // ExifVersion (Undefined, 4 bytes) set to "0232"
+    let ver = *b"0232";
+    exif_entries.push(ExifEntry { tag: 0x9000, field_type: 7, count: 4, value_or_offset: u32::from_le_bytes(ver) });
+
+    // ISO (SHORT)
     let iso_value = shot_iso.unwrap_or(selection.film.iso);
-    let iso_u16 = if iso_value > 65535 {
-      65535
-    } else {
-      iso_value as u16
-    };
-    entries.push(ExifEntry {
-      tag: 0x8827,   // PhotographicSensitivity
-      field_type: 3, // SHORT
-      count: 1,
-      value_or_offset: u32::from(iso_u16), // Value stored directly
-    });
+    let iso_u16 = if iso_value > 65535 { 65535 } else { iso_value as u16 };
+    exif_entries.push(ExifEntry { tag: 0x8827, field_type: 3, count: 1, value_or_offset: u32::from(iso_u16) });
 
-    // Add focal length entry if available (RATIONAL type)
+    // Lens info & focal length
     if let Some(lens) = &selection.lens {
+      add_exif_ascii(&mut exif_entries, &mut exif_external, 0xA433, &lens.maker); // LensMake
+      let lens_model_string = lens.complete_lens_model();
+      add_exif_ascii(&mut exif_entries, &mut exif_external, 0xA434, &lens_model_string); // LensModel
+
       if let Ok(focal_mm) = lens.focal_length.parse::<f32>() {
-        let numerator = (focal_mm * 1000.0) as u32;
-        let denominator = 1000u32;
-
-        let offset = external_data.len() as u32;
-        external_data.extend_from_slice(&numerator.to_le_bytes());
-        external_data.extend_from_slice(&denominator.to_le_bytes());
-
-        entries.push(ExifEntry {
-          tag: 0x920A,   // FocalLength
-          field_type: 5, // RATIONAL
-          count: 1,
-          value_or_offset: offset,
-        });
+        let num = (focal_mm * 1000.0) as u32;
+        let den = 1000u32;
+        let off = exif_external.len() as u32;
+        exif_external.extend_from_slice(&num.to_le_bytes());
+        exif_external.extend_from_slice(&den.to_le_bytes());
+        exif_entries.push(ExifEntry { tag: 0x920A, field_type: 5, count: 1, value_or_offset: off });
       }
     }
 
-    // Sort entries by tag number (EXIF requirement)
-    entries.sort_by_key(|entry| entry.tag);
+    exif_entries.sort_by_key(|e| e.tag);
 
-    // Calculate offset to external data
-    // IFD structure: entry_count(2) + entries(12*count) + next_ifd(4)
-    let external_data_offset = 8 + 2 + (entries.len() * 12) + 4;
+    // Offset where ExifIFD will be placed (from TIFF start)
+    let exif_ifd_offset_from_tiff_start = (8 + ifd0_buf.len()) as u32;
 
-    // Write IFD
-    exif_data.extend_from_slice(&(entries.len() as u16).to_le_bytes());
+    // Patch ExifIFDPointer in IFD0 buffer
+    let mut pos = 2usize; // skip count
+    for e in &ifd0_entries {
+      if e.tag == 0x8769 {
+        let write_at = pos + 2 + 2 + 4; // tag + type + count
+        let bytes = exif_ifd_offset_from_tiff_start.to_le_bytes();
+        ifd0_buf[write_at..write_at + 4].copy_from_slice(&bytes);
+        break;
+      }
+      pos += 12;
+    }
 
-    // Write entries
-    for entry in &entries {
-      exif_data.extend_from_slice(&entry.tag.to_le_bytes());
-      exif_data.extend_from_slice(&entry.field_type.to_le_bytes());
-      exif_data.extend_from_slice(&entry.count.to_le_bytes());
-
-      if entry.field_type == 2 && entry.count > 4 || entry.field_type == 5 {
-        // External data - adjust offset
-        let adjusted_offset = external_data_offset as u32 + entry.value_or_offset;
-        exif_data.extend_from_slice(&adjusted_offset.to_le_bytes());
+    // Serialize Exif SubIFD
+    let mut exif_ifd_buf = Vec::new();
+    exif_ifd_buf.extend_from_slice(&(exif_entries.len() as u16).to_le_bytes());
+    let exif_external_offset = (exif_ifd_offset_from_tiff_start as usize) + 2 + (exif_entries.len() * 12) + 4;
+    for e in &exif_entries {
+      exif_ifd_buf.extend_from_slice(&e.tag.to_le_bytes());
+      exif_ifd_buf.extend_from_slice(&e.field_type.to_le_bytes());
+      exif_ifd_buf.extend_from_slice(&e.count.to_le_bytes());
+      let needs_external = (e.field_type == 2 && e.count > 4) || e.field_type == 5;
+      if needs_external {
+        let adj = (exif_external_offset as u32) + e.value_or_offset;
+        exif_ifd_buf.extend_from_slice(&adj.to_le_bytes());
       } else {
-        // Inline data
-        exif_data.extend_from_slice(&entry.value_or_offset.to_le_bytes());
+        exif_ifd_buf.extend_from_slice(&e.value_or_offset.to_le_bytes());
       }
     }
+    exif_ifd_buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next IFD = 0
+    exif_ifd_buf.extend_from_slice(&exif_external);
 
-    // Next IFD offset (0 = no more IFDs)
-    exif_data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
-
-    // Append external data
-    exif_data.extend_from_slice(&external_data);
+    // Build final EXIF payload: header + IFD0 + ExifIFD
+    exif_data.extend_from_slice(&ifd0_buf);
+    exif_data.extend_from_slice(&exif_ifd_buf);
 
     // Create final APP1 segment
     let segment_length = (exif_data.len() + 2) as u16; // +2 for length field itself


### PR DESCRIPTION
## Problem
Google Photos was not recognizing EXIF metadata from IFEX-edited images, preventing camera/lens/ISO information from displaying in the photo details.

## Solution
Restructured EXIF generation to follow proper TIFF/EXIF standards:

- **IFD0 Structure**: Contains Make, Model, Artist, and ExifIFDPointer (0x8769)
- **Exif SubIFD**: Contains ExifVersion (0x9000), PhotographicSensitivity (ISO), FocalLength, LensMake, and LensModel
- **Proper Offsets**: Fixed offset calculations for external data storage
- **Standards Compliance**: Ensures EXIF structure follows TIFF 6.0 and EXIF 2.32 specifications

## Testing
- ✅ Verified with Google Photos - metadata now displays correctly
- ✅ All lint errors resolved
- ✅ Release build successful
- ✅ EXIF structure validated against working Google Photos images

## Technical Details
- Moved lens and ISO tags to Exif SubIFD where Google Photos expects them
- Added ExifVersion tag for proper EXIF identification
- Fixed borrow checker issues and added proper clippy allowances
- Maintained backward compatibility with existing EXIF readers